### PR TITLE
stack header and nav on small screens

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,23 +37,24 @@
               =link_to 'Log In', new_session_path
         -if flash[:notice]
           %span#notice= flash[:notice]
-      %div#application_nav
-        %ul.tabs
+      %div#application_header_wrapper
+        %div#application_nav
+          %ul.tabs
+            -if @organization && !@organization.new_record?
+              = tab_item('Home', organization_path(@organization))
+              = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
+              = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
+              -if permit? "admin or (manager of :organization)"
+                =tab_item('Settings', edit_organization_path(@organization))
+            -else
+              =tab_item('Home', root_path)
+              -if logged_in? && !current_user.organization.nil?
+                = tab_item(current_user.organization.name, organization_path(current_user.organization))
+        %div#application_header
           -if @organization && !@organization.new_record?
-            = tab_item('Home', organization_path(@organization))
-            = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
-            = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
-            -if permit? "admin or (manager of :organization)"
-              =tab_item('Settings', edit_organization_path(@organization))
+            %h2= link_to @organization.name, @organization
           -else
-            =tab_item('Home', root_path)
-            -if logged_in? && !current_user.organization.nil?
-              = tab_item(current_user.organization.name, organization_path(current_user.organization))
-      %div#application_header
-        -if @organization && !@organization.new_record?
-          %h2= link_to @organization.name, @organization
-        -else
-          %h2 Welcome to #{link_to 'Freehub', root_path}
+            %h2 Welcome to #{link_to 'Freehub', root_path}
       %div.content#application_body
         = yield
         %div{:style => 'clear:both;'}

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,7 +1,7 @@
 /** Top Level Layout **/
 
 #application{
-  max-width:955px;
+  max-width: 955px;
   text-align: left;
   margin: 0 auto;
 }
@@ -15,6 +15,13 @@
   justify-items: center;
   grid-template-areas:
           "column-left column-right";
+}
+
+#application_header_wrapper {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  background: dimgray;
 }
 
 @media (max-width: 800px) {
@@ -61,6 +68,10 @@
 @media (max-width: 800px) {
   #footer .body {
     flex-flow: column;
+  }
+
+  #application_header_wrapper {
+    flex-direction: column-reverse;
   }
 }
 
@@ -134,6 +145,7 @@
 #application_header {
   padding: 14px;
 }
+
 #application_header h2 {
   font-size: 20px;
 }


### PR DESCRIPTION
this change wraps the `#application_header` and `#application_nav` in their own `<div>` to place them in a flexbox row on large screens and column on smaller screens.

![Screen Shot 2019-12-14 at 4 40 58 PM](https://user-images.githubusercontent.com/3011734/70856387-ade7e080-1e90-11ea-80ad-d664172f6723.png)